### PR TITLE
Pass correct width and height to scale filter.

### DIFF
--- a/mpv-gif.lua
+++ b/mpv-gif.lua
@@ -25,7 +25,7 @@ options.outputDirectory = res
 filters = options.fps < 0 and "" or string.format("fps=%d,", options.fps)
 filters = filters .. string.format(
     "scale=%d:%d:flags=lanczos", 
-    options.fps, options.width, options.height
+    options.width, options.height
 )
 
 start_time = -1


### PR DESCRIPTION
As written a config like:

```lua
fps=15
width=-1
height=240
```

was leading to ffmpeg args `fps=15,scale=15:-1:flags=lanczos`, i.e. the fps was doubled up and the height was omitted, resulting in a tiny 15-pixel wide output with an accordingly tiny height instead of the intended 240px wide, appropriately-tall output.

Fixes #2.